### PR TITLE
IssueFix: UI and Data didn't update where status change.

### DIFF
--- a/lib/localdb/task_db.dart
+++ b/lib/localdb/task_db.dart
@@ -41,39 +41,46 @@ class TaskDatabase {
     if (selectedStatus == null) return;
     toDoList[categoryTitle]?.removeAt(index) ?? [];
     if (!toDoList.containsKey(selectedStatus)) {
-      toDoList[selectedStatus]!.add(selectedTask);
-    } else {
-      toDoList[selectedStatus]?.add(
+      toDoList[selectedStatus] = [];
+    }
+
+    toDoList[selectedStatus]!.add(
       Task(taskName: selectedTask.taskName, taskStatus: selectedStatus),
     );
-    }
     dooWeeBox.put(toDoBoxKey, toDoList);
     loadDBData();
   }
 }
 
 class TaskMock {
+  // ignore: unused_field
   static final Map<String, List<Task>> _mockToDoList = {
-    TaskStatus.toDo: [
-      Task(taskName: "Holla", taskStatus: TaskStatus.toDo),
-      Task(taskName: "Another Holla", taskStatus: TaskStatus.toDo),
+    TaskStatus.toDo.name: [
+      Task(taskName: "Holla", taskStatus: TaskStatus.toDo.name),
+      Task(taskName: "Another Holla", taskStatus: TaskStatus.toDo.name),
     ],
 
-    TaskStatus.inProgress: [
-      Task(taskName: "Hello", taskStatus: TaskStatus.inProgress),
-      Task(taskName: "Another Hello", taskStatus: TaskStatus.inProgress),
+    TaskStatus.inProgress.name: [
+      Task(taskName: "Hello", taskStatus: TaskStatus.inProgress.name),
+      Task(taskName: "Another Hello", taskStatus: TaskStatus.inProgress.name),
     ],
 
-    TaskStatus.completed: [
-      Task(taskName: "Mingalabar", taskStatus: TaskStatus.completed),
-      Task(taskName: "Another Mingalabar", taskStatus: TaskStatus.completed),
-      Task(taskName: "Another Mingalabar 2", taskStatus: TaskStatus.completed),
+    TaskStatus.completed.name: [
+      Task(taskName: "Mingalabar", taskStatus: TaskStatus.completed.name),
+      Task(
+        taskName: "Another Mingalabar",
+        taskStatus: TaskStatus.completed.name,
+      ),
+      Task(
+        taskName: "Another Mingalabar 2",
+        taskStatus: TaskStatus.completed.name,
+      ),
     ],
 
-    TaskStatus.onHold: [
-      Task(taskName: "Bonjour", taskStatus: TaskStatus.onHold),
-      Task(taskName: "Another Bonjour", taskStatus: TaskStatus.inProgress),
-      Task(taskName: "Another Bonjour 2", taskStatus: TaskStatus.onHold),
+    TaskStatus.onHold.name: [
+      Task(taskName: "Bonjour", taskStatus: TaskStatus.onHold.name),
+      Task(taskName: "Another Bonjour", taskStatus: TaskStatus.inProgress.name),
+      Task(taskName: "Another Bonjour 2", taskStatus: TaskStatus.onHold.name),
     ],
   };
 }

--- a/lib/model/task.dart
+++ b/lib/model/task.dart
@@ -2,22 +2,38 @@ import 'package:hive/hive.dart';
 
 part 'task.g.dart';
 
-class TaskStatus {
-  static final inProgress = "In Progress";
-  static final completed = "Completed";
-  static final onHold = "On Hold";
-  static final cancelled = "Cancelled";
-  static final toDo = "To Do";
+enum TaskStatus {
+  toDo,
+  inProgress,
+  onHold,
+  completed,
+  cancelled;
+
+  String get name {
+    switch (this) {
+      case TaskStatus.toDo:
+        return 'To Do';
+      case TaskStatus.inProgress:
+        return 'In Progress';
+      case TaskStatus.cancelled:
+        return "Cancelled";
+      case TaskStatus.completed:
+        return "Completed";
+      case TaskStatus.onHold:
+        return "On Hold";
+    }
+  }
 }
 
-// class Task {
-//   String taskName;
-//   String taskStatus;
-
-//   Task({required this.taskName, required this.taskStatus});
+// class TaskStatus {
+//   static final inProgress = "In Progress";
+//   static final completed = "Completed";
+//   static final onHold = "On Hold";
+//   static final cancelled = "Cancelled";
+//   static final toDo = "To Do";
 // }
 
-@HiveType(typeId: 1,adapterName: "TaskAdapter")
+@HiveType(typeId: 1, adapterName: "TaskAdapter")
 class Task {
   Task({required this.taskName, required this.taskStatus});
 

--- a/lib/pages/dowee_home_page.dart
+++ b/lib/pages/dowee_home_page.dart
@@ -18,7 +18,7 @@ class _DoweeHomePageState extends State<DoweeHomePage> {
   TaskDatabase db = TaskDatabase();
 
   //! Selected Status State
-  String? _selectedNewTaskStatus;
+  String? _selectedNewTaskStatus = TaskStatus.toDo.name;
 
   //! New Task Text Field Controlelr
   final _newTaskTFController = TextEditingController();
@@ -80,13 +80,13 @@ class _DoweeHomePageState extends State<DoweeHomePage> {
                               child: Text(
                                 categoryTitle,
                                 style: TextStyle(
-                                  color: categoryTitle == TaskStatus.inProgress
+                                  color: categoryTitle == TaskStatus.inProgress.name
                                       ? Colors.yellow
-                                      : categoryTitle == TaskStatus.completed
+                                      : categoryTitle == TaskStatus.completed.name
                                       ? Colors.green
-                                      : categoryTitle == TaskStatus.onHold
+                                      : categoryTitle == TaskStatus.onHold.name
                                       ? Colors.orange
-                                      : categoryTitle == TaskStatus.toDo
+                                      : categoryTitle == TaskStatus.toDo.name
                                       ? Colors.grey
                                       : Colors.red,
                                   fontWeight: FontWeight.bold,

--- a/lib/utils/components/dowee_task_list.dart
+++ b/lib/utils/components/dowee_task_list.dart
@@ -34,43 +34,47 @@ class DoweeTaskList extends StatelessWidget {
             DropdownButton(
               items: [
                 DropdownMenuItem(
-                  child: Text(TaskStatus.inProgress),
-                  value: TaskStatus.inProgress,
+                  child: Text(TaskStatus.inProgress.name),
+                  value: TaskStatus.inProgress.name,
                 ),
                 DropdownMenuItem(
-                  child: Text(TaskStatus.completed),
-                  value: TaskStatus.completed,
+                  child: Text(TaskStatus.completed.name),
+                  value: TaskStatus.completed.name,
                 ),
                 DropdownMenuItem(
-                  child: Text(TaskStatus.onHold),
-                  value: TaskStatus.onHold,
+                  child: Text(TaskStatus.onHold.name),
+                  value: TaskStatus.onHold.name,
                 ),
                 DropdownMenuItem(
-                  child: Text(TaskStatus.cancelled),
-                  value: TaskStatus.cancelled,
+                  child: Text(TaskStatus.cancelled.name),
+                  value: TaskStatus.cancelled.name,
                 ),
                 DropdownMenuItem(
-                  child: Text(TaskStatus.toDo),
-                  value: TaskStatus.toDo,
+                  child: Text(TaskStatus.toDo.name),
+                  value: TaskStatus.toDo.name,
                 ),
               ],
               value: taskStatus,
               onChanged: onStatusChanged,
-              style: TextStyle(color: Colors.black,fontWeight: FontWeight.w500),
+              style: TextStyle(
+                color: Colors.black,
+                fontWeight: FontWeight.w500,
+              ),
               underline: SizedBox(),
               borderRadius: BorderRadius.circular(12.0),
             ),
           ],
         ),
         decoration: BoxDecoration(
-          color: taskStatus == TaskStatus.inProgress
+          color: taskStatus == TaskStatus.inProgress.name
               ? Colors.yellow
-              : taskStatus == TaskStatus.completed
+              : taskStatus == TaskStatus.completed.name
               ? Colors.green
-              : taskStatus == TaskStatus.onHold
+              : taskStatus == TaskStatus.onHold.name
               ? Colors.orange
-              : taskStatus == TaskStatus.toDo 
-              ? Colors.grey : Colors.red,
+              : taskStatus == TaskStatus.toDo.name
+              ? Colors.grey
+              : Colors.red,
           borderRadius: BorderRadius.circular(12.0),
         ),
       ),

--- a/lib/utils/components/newtask_dialogbox.dart
+++ b/lib/utils/components/newtask_dialogbox.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: sized_box_for_whitespace
+// ignore_for_file: sized_box_for_whitespace, no_leading_underscores_for_local_identifiers
 
 import 'package:dowee_app/model/task.dart';
 import 'package:dowee_app/utils/components/custom_button.dart';
@@ -21,94 +21,104 @@ class NewTaskDialogBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      backgroundColor: Colors.white,
-      content: Container(
-        height: 230,
-        child: Padding(
-          padding: const EdgeInsets.only(top: 15.0),
-          child: Column(
-            spacing: 20.0,
-            children: [
-              //! New Task Text Field
-              TextField(
-                controller: newTaskTFController,
-                decoration: InputDecoration(
-                  hintText: "Just add a new Task..",
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12.0),
-                  ),
-                ),
-              ),
-
-              //! Status Dropdown
-              Container(
-                padding: EdgeInsets.only(left: 5,right: 5),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(12.0),
-                  border: BoxBorder.all(color: Colors.black),
-                ),
-                child: DropdownButton(
-                  items: [
-                    DropdownMenuItem(
-                      child: Text(TaskStatus.inProgress),
-                      value: TaskStatus.inProgress,
-                    ),
-                    DropdownMenuItem(
-                      child: Text(TaskStatus.completed),
-                      value: TaskStatus.completed,
-                    ),
-                    DropdownMenuItem(
-                      child: Text(TaskStatus.onHold),
-                      value: TaskStatus.onHold,
-                    ),
-                    DropdownMenuItem(
-                      child: Text(TaskStatus.cancelled),
-                      value: TaskStatus.cancelled,
-                    ),
-                    DropdownMenuItem(
-                      child: Text(TaskStatus.toDo),
-                      value: TaskStatus.toDo,
-                    ),
-                  ],
-                  value: taskStatus,
-                  onChanged: statusChangePressed,
-                  style: TextStyle(
-                    color: Colors.black,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  underline: SizedBox(),
-                  borderRadius: BorderRadius.circular(12.0),
-                ),
-              ),
-
-              // Buttons
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                spacing: 5.0,
-                //! Add Task Btn
+    String? _selectedStatus = taskStatus;
+    return StatefulBuilder(
+      builder: (BuildContext context, StateSetter setState) {
+        return AlertDialog(
+          backgroundColor: Colors.white,
+          content: Container(
+            height: 230,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 15.0),
+              child: Column(
+                spacing: 20.0,
                 children: [
-                  CustomButton(
-                    btnName: "Add Task",
-                    btnAction: addNewTaskOnPressed,
-                    backgroundColor: Colors.black,
-                    foregroundColor: Colors.white,
+                  //! New Task Text Field
+                  TextField(
+                    controller: newTaskTFController,
+                    decoration: InputDecoration(
+                      hintText: "Just add a new Task..",
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.0),
+                      ),
+                    ),
                   ),
 
-                  //! Cancel Btn
-                  CustomButton(
-                    btnName: "Cancel",
-                    btnAction: cancelPressed,
-                    backgroundColor: Colors.white,
-                    foregroundColor: Colors.black,
+                  //! Status Dropdown
+                  Container(
+                    padding: EdgeInsets.only(left: 5, right: 5),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(12.0),
+                      border: BoxBorder.all(color: Colors.black),
+                    ),
+                    child: DropdownButton(
+                      items: [
+                        DropdownMenuItem(
+                          child: Text(TaskStatus.inProgress.name),
+                          value: TaskStatus.inProgress.name,
+                        ),
+                        DropdownMenuItem(
+                          child: Text(TaskStatus.completed.name),
+                          value: TaskStatus.completed.name,
+                        ),
+                        DropdownMenuItem(
+                          child: Text(TaskStatus.onHold.name),
+                          value: TaskStatus.onHold.name,
+                        ),
+                        DropdownMenuItem(
+                          child: Text(TaskStatus.cancelled.name),
+                          value: TaskStatus.cancelled.name,
+                        ),
+                        DropdownMenuItem(
+                          child: Text(TaskStatus.toDo.name),
+                          value: TaskStatus.toDo.name,
+                        ),
+                      ],
+                      value: _selectedStatus,
+                      onChanged: (value) {
+                        setState(() {
+                          _selectedStatus = value;
+                        });
+                        statusChangePressed?.call(value);
+                      },
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      underline: SizedBox(),
+                      borderRadius: BorderRadius.circular(12.0),
+                    ),
+                  ),
+
+                  // Buttons
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    spacing: 5.0,
+                    //! Add Task Btn
+                    children: [
+                      CustomButton(
+                        btnName: "Add Task",
+                        btnAction: addNewTaskOnPressed,
+                        backgroundColor: Colors.black,
+                        foregroundColor: Colors.white,
+                      ),
+
+                      //! Cancel Btn
+                      CustomButton(
+                        btnName: "Cancel",
+                        btnAction: cancelPressed,
+                        backgroundColor: Colors.white,
+                        foregroundColor: Colors.black,
+                      ),
+                    ],
                   ),
                 ],
               ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Standardize task status handling by replacing string constants with an enum and refactor the new-task dialog to live-update status selections and persist changes correctly.

Bug Fixes:
- Ensure task status dropdown updates both the dialog UI and persisted data on change

Enhancements:
- Convert TaskStatus from static strings to an enum with a name getter and update all dropdowns, color logic, and persistence to use enum names
- Refactor NewTaskDialogBox into a stateful builder to track and apply status selections immediately
- Initialize missing status categories dynamically in TaskDatabase before adding moved tasks

Chores:
- Add lint rule to ignore leading underscores for local identifiers